### PR TITLE
Add tooltips to measures on timeline

### DIFF
--- a/packages/flipper-plugin-performance/src/lib/formatMilliseconds.js
+++ b/packages/flipper-plugin-performance/src/lib/formatMilliseconds.js
@@ -1,0 +1,5 @@
+import { formatMillisecondsToParts } from './formatMillisecondsToParts';
+export function formatMilliseconds(millis) {
+  const { value, unit } = formatMillisecondsToParts(millis);
+  return `${value}${unit}`;
+}


### PR DESCRIPTION
This PR adds tooltips when hovering over individual measures on the timeline. Additionally it centralizes layouting logic to one place that make the code a bit simpler and should also be slightly faster. 

<img width="353" alt="Screenshot 2021-01-29 at 18 09 11" src="https://user-images.githubusercontent.com/378279/106305546-1d6b8b80-625d-11eb-80a7-c981f3e0eea7.png">
