### PR TITLE
Respect root project gradle settings

### DIFF
--- a/examples/vanilla/android/build.gradle
+++ b/examples/vanilla/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "29.0.2"
-        minSdkVersion = 21
+        minSdkVersion = 16
         compileSdkVersion = 29
         targetSdkVersion = 29
     }

--- a/packages/react-native-performance/android/build.gradle
+++ b/packages/react-native-performance/android/build.gradle
@@ -12,22 +12,19 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 30
-    buildToolsVersion "30.0.2"
+    compileSdkVersion safeExtGet('compileSdkVersion', 30)
+    buildToolsVersion safeExtGet('buildToolsVersion', "30.0.2")
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 30
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 30)
     }
 
-    buildTypes {
-        release {
-            minifyEnabled false
-        }
-    }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -35,12 +32,14 @@ android {
 }
 
 repositories {
-    maven {
-        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        url "$rootDir/../node_modules/react-native/android"
+    if (project == rootProject) {
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url "$rootDir/../../../node_modules/react-native/android"
+        }
+        google()
+        jcenter()
     }
-    google()
-    jcenter()
 }
 
 dependencies {

--- a/packages/react-native-performance/android/gradle.properties
+++ b/packages/react-native-performance/android/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/packages/react-native-performance/android/src/main/java/com/oblador/performance/PerformanceModule.java
+++ b/packages/react-native-performance/android/src/main/java/com/oblador/performance/PerformanceModule.java
@@ -18,7 +18,6 @@ import java.lang.StringBuffer;
 import java.util.Map;
 import java.util.HashMap;
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 


### PR DESCRIPTION
`minSdkVersion` was set to 21, but works just fine with 16 which is the default for RN projects so I changed it so that 16 is default but that it would respect the settings from the root project. Additionally I made it compile with Android Studio, and I think the if statement should make it not break in consumers anymore. 