### PR TITLE
fix flipper-reporter peerDependency, update repository fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "react-native-performance-root",
   "private": true,
   "author": "Joel Arvidsson",
   "license": "MIT",

--- a/packages/flipper-plugin-performance/package.json
+++ b/packages/flipper-plugin-performance/package.json
@@ -11,7 +11,8 @@
   "icon": "flash-default",
   "repository": {
     "type": "git",
-    "url": "https://github.com/oblador/react-native-performance.git"
+    "url": "https://github.com/oblador/react-native-performance.git",
+    "directory": "packages/flipper-plugin-performance"
   },
   "files": [
     "index.js",

--- a/packages/react-native-performance-flipper-reporter/package.json
+++ b/packages/react-native-performance-flipper-reporter/package.json
@@ -5,7 +5,8 @@
   "homepage": "https://github.com/oblador/react-native-performance",
   "repository": {
     "type": "git",
-    "url": "https://github.com/oblador/react-native-performance.git"
+    "url": "https://github.com/oblador/react-native-performance.git",
+    "directory": "packages/react-native-performance-flipper-reporter"
   },
   "main": "src/index.js",
   "files": [
@@ -26,7 +27,7 @@
   "author": "Joel Arvidsson",
   "license": "MIT",
   "peerDependencies": {
-    "flipper-react-native": "*",
+    "react-native-flipper": "*",
     "react-native-performance": "*"
   }
 }

--- a/packages/react-native-performance/package.json
+++ b/packages/react-native-performance/package.json
@@ -5,7 +5,8 @@
   "homepage": "https://github.com/oblador/react-native-performance",
   "repository": {
     "type": "git",
-    "url": "https://github.com/oblador/react-native-performance.git"
+    "url": "https://github.com/oblador/react-native-performance.git",
+    "directory": "packages/react-native-performance"
   },
   "main": "src/index.ts",
   "files": [


### PR DESCRIPTION
This small PR:
* fixes the typo in the `react-native-performance-flipper-reporter` peer dependency (currently used name do not exist in the npm registry), 
* adds `directory` data to the `repository` field in packages `package.json` files (https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository),
* removes `name` from the main workspace file, which is not necessary in the current repository setup.

It looks like the new release of `react-native-performance-flipper-reporter` will be required to fix the `example` and other projects using that package.