### PR TITLE
Fix lack of fallback values for user timing 3 implementation

### DIFF
--- a/packages/react-native-performance/package.json
+++ b/packages/react-native-performance/package.json
@@ -10,7 +10,7 @@
   },
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
-  "types": "lib/typescript/src/index.d.ts",
+  "types": "lib/typescript/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",
   "files": [
@@ -53,7 +53,12 @@
     "targets": [
       "commonjs",
       "module",
-      "typescript"
+      [
+        "typescript",
+        {
+          "project": "tsconfig.build.json"
+        }
+      ]
     ]
   }
 }

--- a/packages/react-native-performance/src/performance.ts
+++ b/packages/react-native-performance/src/performance.ts
@@ -127,6 +127,7 @@ export const createPerformance = (now: () => number = defaultNow) => {
     let detail: any;
 
     if (
+      startOrMeasureOptions &&
       typeof startOrMeasureOptions === 'object' &&
       startOrMeasureOptions.constructor == Object
     ) {
@@ -162,6 +163,8 @@ export const createPerformance = (now: () => number = defaultNow) => {
         end =
           convertMarkToTimestamp(startOrMeasureOptions.start) +
           convertMarkToTimestamp(startOrMeasureOptions.duration);
+      } else {
+        end = now();
       }
 
       if (startOrMeasureOptions && startOrMeasureOptions.start) {
@@ -174,6 +177,8 @@ export const createPerformance = (now: () => number = defaultNow) => {
         start =
           convertMarkToTimestamp(startOrMeasureOptions.end) -
           convertMarkToTimestamp(startOrMeasureOptions.duration);
+      } else {
+        start = timeOrigin;
       }
     } else {
       if (endMark) {

--- a/packages/react-native-performance/test/user-timing-3.spec.ts
+++ b/packages/react-native-performance/test/user-timing-3.spec.ts
@@ -1,0 +1,60 @@
+import { createPerformance } from '../src/performance';
+
+test('Performance.measure with start', () => {
+  const mockNow = jest.fn();
+  mockNow.mockReturnValue(1);
+  const { performance } = createPerformance(mockNow);
+
+  mockNow.mockReturnValue(2);
+  performance.mark('start');
+  mockNow.mockReturnValue(8);
+  const measure1 = performance.measure('measure1', 'start');
+  const measure2 = performance.measure('measure2', { start: 'start' });
+  expect(measure1.startTime).toBe(2);
+  expect(measure2.startTime).toBe(2);
+  expect(measure1.duration).toBe(6);
+  expect(measure2.duration).toBe(6);
+});
+
+test('Performance.measure with end', () => {
+  const mockNow = jest.fn();
+  mockNow.mockReturnValue(1);
+  const { performance } = createPerformance(mockNow);
+
+  mockNow.mockReturnValue(5);
+  performance.mark('end');
+  mockNow.mockReturnValue(8);
+  const measure1 = performance.measure('measure1', null, 'end');
+  const measure2 = performance.measure('measure2', {
+    end: 'end',
+    detail: 'lol',
+  });
+  expect(measure1.startTime).toBe(1);
+  expect(measure2.startTime).toBe(1);
+  expect(measure1.duration).toBe(4);
+  expect(measure2.duration).toBe(4);
+});
+
+test('Performance.measure with duration', () => {
+  const mockNow = jest.fn();
+  mockNow.mockReturnValue(1);
+  const { performance } = createPerformance(mockNow);
+
+  mockNow.mockReturnValue(2);
+  performance.mark('start');
+  mockNow.mockReturnValue(5);
+  performance.mark('end');
+  mockNow.mockReturnValue(8);
+  const measure1 = performance.measure('measure2', {
+    duration: 1,
+    end: 'end',
+  });
+  expect(measure1.startTime).toBe(4);
+  expect(measure1.duration).toBe(1);
+  const measure2 = performance.measure('measure2', {
+    duration: 2,
+    start: 'start',
+  });
+  expect(measure2.startTime).toBe(2);
+  expect(measure2.duration).toBe(2);
+});

--- a/packages/react-native-performance/tsconfig.build.json
+++ b/packages/react-native-performance/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["test"]
+}


### PR DESCRIPTION
Not perfect to have the default values implemented twice, but I also don't want to call `now()` unless necessary. 