### PR TITLE
Update the name for flipper plugin

### DIFF
--- a/packages/flipper-plugin-performance/README.md
+++ b/packages/flipper-plugin-performance/README.md
@@ -11,7 +11,7 @@ It can be used as a generic profiler, or used together with the `react-native-pe
 ### Flipper Desktop
 
 1. Go to **Manage Plugins** by pressing the button in the lower left corner of the Flipper app, or in the **View** menu
-2. Select **Install Plugins** and search for `react-native-performance`
+2. Select **Install Plugins** and search for `flipper-plugin-performance`
 3. Press the **Install** button
 
 ### Optional: React Native Performance


### PR DESCRIPTION
Use the new package name from npm `flipper-plugin-performance`. The name from the readme links to an older version of the plugin `0.6.0` which is outdated by 2 months.