### PR TITLE
android native start time fix

### DIFF
--- a/packages/react-native-performance/android/src/main/AndroidManifest.xml
+++ b/packages/react-native-performance/android/src/main/AndroidManifest.xml
@@ -2,4 +2,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.oblador.performance">
 
+    <application>
+        <provider
+            android:name=".StartTimeProvider"
+            android:authorities="${applicationId}.start.time.provider"
+            android:exported="false" />
+
+    </application>
+
 </manifest>

--- a/packages/react-native-performance/android/src/main/java/com/oblador/performance/PerformanceModule.java
+++ b/packages/react-native-performance/android/src/main/java/com/oblador/performance/PerformanceModule.java
@@ -1,33 +1,28 @@
 package com.oblador.performance;
 
-import android.os.Process;
 import android.os.SystemClock;
 import androidx.annotation.NonNull;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMarker;
 import com.facebook.react.bridge.ReactMarkerConstants;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.bridge.Arguments;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 
-import java.lang.StringBuffer;
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 
 public class PerformanceModule extends ReactContextBaseJavaModule {
     public static final String PERFORMANCE_MODULE = "RNPerformanceManager";
     public static final String BRIDGE_SETUP_START = "bridgeSetupStart";
-    private static final long MODULE_INITIALIZED_AT = SystemClock.uptimeMillis();
-    private static final long START_UP_DURATION = Process.getElapsedCpuTime();
 
     private boolean eventsBuffered = true;
     private static final Map<String, Long> markBuffer = new HashMap<>();
 
     public PerformanceModule(@NonNull final ReactApplicationContext reactContext) {
         super(reactContext);
-
         setupMarkerListener();
     }
 
@@ -35,49 +30,49 @@ public class PerformanceModule extends ReactContextBaseJavaModule {
     // to capture all events
     public static void setupListener() {
         ReactMarker.addListener(
-            (name, tag, instanceKey) -> {
-                switch (name) {
-                    case RELOAD:
-                        markBuffer.clear();
-                        markBuffer.put(BRIDGE_SETUP_START, SystemClock.uptimeMillis());
-                        break;
-                    case ATTACH_MEASURED_ROOT_VIEWS_END:
-                    case ATTACH_MEASURED_ROOT_VIEWS_START:
-                    case BUILD_NATIVE_MODULE_REGISTRY_END:
-                    case BUILD_NATIVE_MODULE_REGISTRY_START:
-                    case CONTENT_APPEARED:
-                    case CREATE_CATALYST_INSTANCE_END:
-                    case CREATE_CATALYST_INSTANCE_START:
-                    case CREATE_REACT_CONTEXT_END:
-                    case CREATE_REACT_CONTEXT_START:
-                    case CREATE_UI_MANAGER_MODULE_CONSTANTS_END:
-                    case CREATE_UI_MANAGER_MODULE_CONSTANTS_START:
-                    case CREATE_UI_MANAGER_MODULE_END:
-                    case CREATE_UI_MANAGER_MODULE_START:
-                    case CREATE_VIEW_MANAGERS_END:
-                    case CREATE_VIEW_MANAGERS_START:
-                    case DOWNLOAD_END:
-                    case DOWNLOAD_START:
-                    case LOAD_REACT_NATIVE_SO_FILE_END:
-                    case LOAD_REACT_NATIVE_SO_FILE_START:
-                    case PRE_RUN_JS_BUNDLE_START:
-                    case PRE_SETUP_REACT_CONTEXT_END:
-                    case PRE_SETUP_REACT_CONTEXT_START:
-                    case PROCESS_CORE_REACT_PACKAGE_END:
-                    case PROCESS_CORE_REACT_PACKAGE_START:
-                    case REACT_CONTEXT_THREAD_END:
-                    case REACT_CONTEXT_THREAD_START:
-                    case RUN_JS_BUNDLE_END:
-                    case RUN_JS_BUNDLE_START:
-                    case SETUP_REACT_CONTEXT_END:
-                    case SETUP_REACT_CONTEXT_START:
-                    case VM_INIT:
-                        long startTime = SystemClock.uptimeMillis();
-                        markBuffer.put(getMarkName(name), startTime);
-                    break;
+                (name, tag, instanceKey) -> {
+                    switch (name) {
+                        case RELOAD:
+                            markBuffer.clear();
+                            markBuffer.put(BRIDGE_SETUP_START, SystemClock.uptimeMillis());
+                            break;
+                        case ATTACH_MEASURED_ROOT_VIEWS_END:
+                        case ATTACH_MEASURED_ROOT_VIEWS_START:
+                        case BUILD_NATIVE_MODULE_REGISTRY_END:
+                        case BUILD_NATIVE_MODULE_REGISTRY_START:
+                        case CONTENT_APPEARED:
+                        case CREATE_CATALYST_INSTANCE_END:
+                        case CREATE_CATALYST_INSTANCE_START:
+                        case CREATE_REACT_CONTEXT_END:
+                        case CREATE_REACT_CONTEXT_START:
+                        case CREATE_UI_MANAGER_MODULE_CONSTANTS_END:
+                        case CREATE_UI_MANAGER_MODULE_CONSTANTS_START:
+                        case CREATE_UI_MANAGER_MODULE_END:
+                        case CREATE_UI_MANAGER_MODULE_START:
+                        case CREATE_VIEW_MANAGERS_END:
+                        case CREATE_VIEW_MANAGERS_START:
+                        case DOWNLOAD_END:
+                        case DOWNLOAD_START:
+                        case LOAD_REACT_NATIVE_SO_FILE_END:
+                        case LOAD_REACT_NATIVE_SO_FILE_START:
+                        case PRE_RUN_JS_BUNDLE_START:
+                        case PRE_SETUP_REACT_CONTEXT_END:
+                        case PRE_SETUP_REACT_CONTEXT_START:
+                        case PROCESS_CORE_REACT_PACKAGE_END:
+                        case PROCESS_CORE_REACT_PACKAGE_START:
+                        case REACT_CONTEXT_THREAD_END:
+                        case REACT_CONTEXT_THREAD_START:
+                        case RUN_JS_BUNDLE_END:
+                        case RUN_JS_BUNDLE_START:
+                        case SETUP_REACT_CONTEXT_END:
+                        case SETUP_REACT_CONTEXT_START:
+                        case VM_INIT:
+                            long startTime = SystemClock.uptimeMillis();
+                            markBuffer.put(getMarkName(name), startTime);
+                            break;
 
+                    }
                 }
-            }
         );
     }
 
@@ -99,28 +94,28 @@ public class PerformanceModule extends ReactContextBaseJavaModule {
     @Override
     @NonNull
     public String getName() {
-      return PERFORMANCE_MODULE;
+        return PERFORMANCE_MODULE;
     }
 
     private void emitNativeStartupTime() {
-        safelyEmitMark("nativeLaunchStart", (MODULE_INITIALIZED_AT - START_UP_DURATION));
-        safelyEmitMark("nativeLaunchEnd", MODULE_INITIALIZED_AT);
+        safelyEmitMark("nativeLaunchStart", StartTimeProvider.getStartTime());
+        safelyEmitMark("nativeLaunchEnd", StartTimeProvider.getEndTime());
     }
 
     private void setupMarkerListener() {
         ReactMarker.addListener(
-            (name, tag, instanceKey) -> {
-                switch (name) {
-                    case CONTENT_APPEARED:
-                        eventsBuffered = false;
-                        emitNativeStartupTime();
-                        emitBufferedMarks();
-                        break;
-                    case RELOAD:
-                        eventsBuffered = true;
-                        break;
+                (name, tag, instanceKey) -> {
+                    switch (name) {
+                        case CONTENT_APPEARED:
+                            eventsBuffered = false;
+                            emitNativeStartupTime();
+                            emitBufferedMarks();
+                            break;
+                        case RELOAD:
+                            eventsBuffered = true;
+                            break;
+                    }
                 }
-            }
         );
     }
 
@@ -150,7 +145,7 @@ public class PerformanceModule extends ReactContextBaseJavaModule {
         params.putString("name", name);
         params.putInt("startTime", (int) startTime);
         getReactApplicationContext()
-            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-            .emit(eventName, params);
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                .emit(eventName, params);
     }
 }

--- a/packages/react-native-performance/android/src/main/java/com/oblador/performance/StartTimeProvider.java
+++ b/packages/react-native-performance/android/src/main/java/com/oblador/performance/StartTimeProvider.java
@@ -7,7 +7,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Process;
 import android.os.SystemClock;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -48,7 +47,6 @@ public class StartTimeProvider extends ContentProvider {
 
     @Override
     public boolean onCreate() {
-        Log.v("mymeasure", "mymeasure content provider is up.");
         setEndTime();
         setStartTime();
         return false;

--- a/packages/react-native-performance/android/src/main/java/com/oblador/performance/StartTimeProvider.java
+++ b/packages/react-native-performance/android/src/main/java/com/oblador/performance/StartTimeProvider.java
@@ -1,0 +1,84 @@
+package com.oblador.performance;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Process;
+import android.os.SystemClock;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class StartTimeProvider extends ContentProvider {
+
+    private static long startTime = 0;
+    private static long endTime = 0;
+    private static final long MINUTE_IN_MS = 60000;
+
+    public static long getStartTime() {
+        return startTime;
+    }
+
+    public static long getEndTime() {
+        return endTime;
+    }
+
+    private static void setStartTime() {
+        if (startTime == 0) {
+            long fallbackTime = endTime - Process.getElapsedCpuTime();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                startTime = Process.getStartUptimeMillis();
+                if (endTime - startTime > MINUTE_IN_MS) {
+                    startTime = fallbackTime;
+                }
+            } else {
+                startTime = fallbackTime;
+            }
+        }
+    }
+
+    private static void setEndTime() {
+        if (endTime == 0) {
+            endTime = SystemClock.uptimeMillis();
+        }
+    }
+
+    @Override
+    public boolean onCreate() {
+        Log.v("mymeasure", "mymeasure content provider is up.");
+        setEndTime();
+        setStartTime();
+        return false;
+    }
+
+    @Nullable
+    @Override
+    public Cursor query(@NonNull Uri uri, @Nullable String[] projection, @Nullable String selection, @Nullable String[] selectionArgs, @Nullable String sortOrder) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getType(@NonNull Uri uri) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Uri insert(@NonNull Uri uri, @Nullable ContentValues values) {
+        return null;
+    }
+
+    @Override
+    public int delete(@NonNull Uri uri, @Nullable String selection, @Nullable String[] selectionArgs) {
+        return 0;
+    }
+
+    @Override
+    public int update(@NonNull Uri uri, @Nullable ContentValues values, @Nullable String selection, @Nullable String[] selectionArgs) {
+        return 0;
+    }
+}


### PR DESCRIPTION
Instead of getting process start time from proc stat file, it is getting process cpu elapsed time and subtracting from uptime of static initialised module variable.

I tried existing and new measurement with Android 11 and Android 6 emulator 10 times. Here are the results.(the first number is new and the second number is existing measurement.)

Vanilla: 
Android M:  (63 - 66), (46 - 48), (67 - 64), (51-50), (63-65), (60-56), (51-68), (26-42), (40-52), (29-38) 
Android 11: (98 - 190), (111 - 218), (120 - 188), (116 - 222), (96 - 173), (100 - 176), (97 - 204), (85 - 175), (194 - 260), (98 - 189) 
RNN:
Android M:  (56 - 59), (79-84), (43 - 71). (77 - 87). (59 - 74), (91 - 91), (49-69), (48-79), (59-60), (44-62)
Android 11: (422 - 610), (246 - 310), (403 - 578), (262 - 334), (246 - 347), (272 - 376), (274 - 337), (283 - 389), (253 - 318), (226 - 310)