### PR TITLE
Increase initOrder of content provider

### DIFF
--- a/packages/react-native-performance/android/src/main/AndroidManifest.xml
+++ b/packages/react-native-performance/android/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
         <provider
             android:name=".StartTimeProvider"
             android:authorities="${applicationId}.start.time.provider"
-            android:exported="false" />
+            android:exported="false"
+            android:initOrder="200" />
 
     </application>
 


### PR DESCRIPTION
`android:initOrder` provides the order in which the content provider should be instantiated, relative to other content providers hosted by the same process. When there are dependencies among content providers, setting this attribute for each of them ensures that they are created in the order required by those dependencies. The value is a simple integer, with higher numbers being initialized first. Source https://developer.android.com/guide/topics/manifest/provider-element

With Firebase setting [100 as `initOrder`](https://github.com/firebase/firebase-android-sdk/blob/c56a9769b723bb96551ed2aa9fd3731e541ca018/firebase-common/src/main/AndroidManifest.xml#L28), we can use 200 here to run earlier in the process.