### PR TITLE
Add metric "unit" option

### DIFF
--- a/packages/react-native-performance-flipper-reporter/src/index.js
+++ b/packages/react-native-performance-flipper-reporter/src/index.js
@@ -77,6 +77,14 @@ const getResourceName = (url) => {
   return urlSansQuery.replace(/^https?:\/\//i, '');
 };
 
+const getMetricUnit = (metric) => {
+  if (metric.name === 'bundleSize') {
+    return 'bytes';
+  }
+
+  return metric.unit;
+};
+
 export function setupDefaultFlipperReporter() {
   let observers = [];
   const sessionStartedAt = Date.now();
@@ -179,7 +187,7 @@ export function setupDefaultFlipperReporter() {
               name: entry.name,
               startTime: entry.startTime,
               value: entry.value,
-              unit: entry.name === 'bundleSize' ? 'bytes' : undefined,
+              unit: getMetricUnit(entry),
             }))
           );
         },

--- a/packages/react-native-performance/src/performance-entry.ts
+++ b/packages/react-native-performance/src/performance-entry.ts
@@ -1,3 +1,5 @@
+import type { LiteralUnion } from './utility-types';
+
 type MarkOptions = {
   startTime?: number;
   detail?: any;
@@ -7,7 +9,13 @@ type MetricOptions = {
   startTime: number;
   value: string | number;
   detail?: any;
+  unit?: MetricUnit;
 };
+
+export type MetricUnit = LiteralUnion<MetricUnitBytes | MetricUnitMilliseconds>;
+
+type MetricUnitBytes = 'b' | 'byte' | 'bytes';
+type MetricUnitMilliseconds = 'ms' | 'millisecond' | 'milliseconds';
 
 type MeasureOptions = {
   startTime?: number;
@@ -78,11 +86,13 @@ export class PerformanceReactNativeMark extends PerformanceEntry {
 export class PerformanceMetric extends PerformanceEntry {
   value: string | number;
   detail?: any;
+  unit?: MetricUnit;
 
   constructor(name: string, metricOptions: MetricOptions) {
     super(name, 'metric', metricOptions.startTime, 0);
     this.value = metricOptions.value;
     this.detail = metricOptions.detail;
+    this.unit = metricOptions.unit;
   }
 
   toJSON() {
@@ -93,6 +103,7 @@ export class PerformanceMetric extends PerformanceEntry {
       duration: this.duration,
       detail: this.detail,
       value: this.value,
+      unit: this.unit,
     };
   }
 }

--- a/packages/react-native-performance/src/performance.ts
+++ b/packages/react-native-performance/src/performance.ts
@@ -8,6 +8,7 @@ import {
   PerformanceEntry,
   PerformanceReactNativeMark,
   PerformanceResourceTiming,
+  MetricUnit,
 } from './performance-entry';
 
 // @ts-ignore
@@ -29,8 +30,9 @@ export type StartOrMeasureOptions = string | MeasureOptions | undefined;
 
 export type MetricOptions = {
   startTime: number;
-  detail: any;
+  detail?: any;
   value: number | string;
+  unit?: MetricUnit;
 };
 
 export type ValueOrOptions = number | string | MetricOptions;
@@ -191,6 +193,7 @@ export const createPerformance = (now: () => number = defaultNow) => {
     let value: string | number;
     let startTime: number | undefined;
     let detail: any;
+    let unit: MetricUnit | undefined;
 
     if (
       typeof valueOrOptions === 'object' &&
@@ -204,6 +207,7 @@ export const createPerformance = (now: () => number = defaultNow) => {
       value = valueOrOptions.value;
       startTime = valueOrOptions.startTime;
       detail = valueOrOptions.detail;
+      unit = valueOrOptions.unit;
     } else if (
       typeof valueOrOptions === 'undefined' ||
       valueOrOptions === null
@@ -220,6 +224,7 @@ export const createPerformance = (now: () => number = defaultNow) => {
         startTime: startTime ? startTime : now(),
         value,
         detail,
+        unit,
       })
     );
   };

--- a/packages/react-native-performance/src/utility-types.ts
+++ b/packages/react-native-performance/src/utility-types.ts
@@ -1,0 +1,1 @@
+export type LiteralUnion<T extends U, U = string> = T | (U & {});


### PR DESCRIPTION
Right now user metrics are just a number/string value, but metrics without specified unit (like second, percent, etc) are almost unusable. 