### PR TITLE
Use unix epoch timestamps

### DIFF
--- a/packages/react-native-performance/android/src/main/java/com/oblador/performance/PerformanceModule.java
+++ b/packages/react-native-performance/android/src/main/java/com/oblador/performance/PerformanceModule.java
@@ -1,6 +1,5 @@
 package com.oblador.performance;
 
-import android.os.SystemClock;
 import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.Arguments;
@@ -13,6 +12,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.lang.System;
 
 public class PerformanceModule extends ReactContextBaseJavaModule {
     public static final String PERFORMANCE_MODULE = "RNPerformanceManager";
@@ -34,7 +34,7 @@ public class PerformanceModule extends ReactContextBaseJavaModule {
                     switch (name) {
                         case RELOAD:
                             markBuffer.clear();
-                            markBuffer.put(BRIDGE_SETUP_START, SystemClock.uptimeMillis());
+                            markBuffer.put(BRIDGE_SETUP_START, System.currentTimeMillis());
                             break;
                         case ATTACH_MEASURED_ROOT_VIEWS_END:
                         case ATTACH_MEASURED_ROOT_VIEWS_START:
@@ -67,7 +67,7 @@ public class PerformanceModule extends ReactContextBaseJavaModule {
                         case SETUP_REACT_CONTEXT_END:
                         case SETUP_REACT_CONTEXT_START:
                         case VM_INIT:
-                            long startTime = SystemClock.uptimeMillis();
+                            long startTime = System.currentTimeMillis();
                             markBuffer.put(getMarkName(name), startTime);
                             break;
 
@@ -143,7 +143,7 @@ public class PerformanceModule extends ReactContextBaseJavaModule {
                       long startTime) {
         WritableMap params = Arguments.createMap();
         params.putString("name", name);
-        params.putInt("startTime", (int) startTime);
+        params.putDouble("startTime", startTime);
         getReactApplicationContext()
                 .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                 .emit(eventName, params);

--- a/packages/react-native-performance/android/src/main/java/com/oblador/performance/StartTimeProvider.java
+++ b/packages/react-native-performance/android/src/main/java/com/oblador/performance/StartTimeProvider.java
@@ -6,7 +6,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Process;
-import android.os.SystemClock;
+import java.lang.System;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -41,7 +41,7 @@ public class StartTimeProvider extends ContentProvider {
 
     private static void setEndTime() {
         if (endTime == 0) {
-            endTime = SystemClock.uptimeMillis();
+            endTime = System.currentTimeMillis();
         }
     }
 

--- a/packages/react-native-performance/ios/RNPerformanceManager.m
+++ b/packages/react-native-performance/ios/RNPerformanceManager.m
@@ -1,11 +1,13 @@
 #import "RNPerformanceManager.h"
 #import <sys/sysctl.h>
 #include <math.h>
+#include <chrono>
 #import <QuartzCore/QuartzCore.h>
 #import <React/RCTRootView.h>
 #import <React/RCTPerformanceLogger.h>
 
-static CFTimeInterval getProcessStartTime() {
+static CFTimeInterval getProcessStartTime()
+{
     size_t len = 4;
     int mib[len];
     struct kinfo_proc kp;
@@ -17,6 +19,11 @@ static CFTimeInterval getProcessStartTime() {
 
     struct timeval startTime = kp.kp_proc.p_un.__p_starttime;
     return startTime.tv_sec + startTime.tv_usec / 1e6;
+}
+
+static int64_t getTimestamp()
+{
+    return std::chrono::system_clock::now().time_since_epoch() / std::chrono::milliseconds(1);
 }
 
 static int64_t sNativeLaunchStart;
@@ -32,9 +39,8 @@ RCT_EXPORT_MODULE();
 + (void) initialize
 {
     [super initialize];
-    CFTimeInterval absoluteTimeToRelativeTime =  CACurrentMediaTime() - [NSDate date].timeIntervalSince1970;
-    sNativeLaunchStart = (getProcessStartTime() + absoluteTimeToRelativeTime) * 1000;
-    sNativeLaunchEnd = CACurrentMediaTime() * 1000;
+    sNativeLaunchStart = (getProcessStartTime() - [NSDate date].timeIntervalSince1970) * 1000 + getTimestamp();
+    sNativeLaunchEnd = getTimestamp();
 }
 
 - (void)setBridge:(RCTBridge *)bridge
@@ -49,7 +55,7 @@ RCT_EXPORT_MODULE();
 
 - (void)contentDidAppear
 {
-    int64_t startTime = CACurrentMediaTime() * 1000;
+    int64_t startTime = getTimestamp();
     [self emitMarkNamed:@"nativeLaunchStart" withStartTime:sNativeLaunchStart];
     [self emitMarkNamed:@"nativeLaunchEnd" withStartTime:sNativeLaunchEnd];
     [self emitTag:RCTPLScriptDownload withNamePrefix:@"download"];
@@ -66,6 +72,7 @@ RCT_EXPORT_MODULE();
 
 - (void)invalidate
 {
+    [super invalidate];
     NSNotificationCenter *notificationCenter = NSNotificationCenter.defaultCenter;
     [notificationCenter removeObserver:self];
 }
@@ -88,6 +95,7 @@ RCT_EXPORT_MODULE();
         NSLog(@"Ignoring marks prefixed %@ (%lu) as data is unavailable (duration: %lld, end: %lld)", namePrefix, (unsigned long)tag, duration, end);
         return;
     }
+    end += getTimestamp() - (CACurrentMediaTime() * 1000);
     [self emitMarkNamed:[namePrefix stringByAppendingString:@"Start"] withStartTime:end-duration];
     [self emitMarkNamed:[namePrefix stringByAppendingString:@"End"] withStartTime:end];
 }
@@ -107,7 +115,7 @@ RCT_EXPORT_MODULE();
     if (hasListeners) {
         [self sendEventWithName:@"metric" body:@{
             @"name": name,
-            @"startTime": @(CACurrentMediaTime() * 1000),
+            @"startTime": @(getTimestamp()),
             @"value": value
         }];
     }

--- a/packages/react-native-performance/ios/react-native-performance.podspec
+++ b/packages/react-native-performance/ios/react-native-performance.podspec
@@ -11,8 +11,8 @@ Pod::Spec.new do |s|
   s.license      = package['license']
   s.source       = { :git => 'https://github.com/oblador/react-native-performance.git', :tag => "v#{s.version}" }
 
-  s.platform     = :ios, "9.0"
-  s.source_files = "**/*.{h,m}"
+  s.platform     = :ios, "11.0"
+  s.source_files = "**/*.{h,m,mm}"
 
   s.dependency 'React-Core'
 end


### PR DESCRIPTION
In React Native 0.68 the `Performance.now()` implementation on both iOS and Android changed to use unix epoch timestamps instead of a monotonic clock in https://github.com/facebook/react-native/pull/32695. 

This is clearly inferior for the purposes of performance metrics as it risks skewing durations, but it's more important to keep the native marks in sync with the RN implementation which this PR aims to do. This means this is a breaking change only compatible with RN >=0.68. 