### PR TITLE
Support TurboModules

### DIFF
--- a/examples/react-native-navigation/ios/Podfile.lock
+++ b/examples/react-native-navigation/ios/Podfile.lock
@@ -551,7 +551,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 83ab4f136376e39e8b324cef45977e1ac8100265
   React-logger: b2c25c4769127bebfaf7259b5434318665716982
   react-native-flipper: 3d9e214b412b3ce81e0d73bdcdc8097c0b0e8578
-  react-native-performance: f4b6604a9d5a8a7407e34a82fab6c641d9a3ec12
+  react-native-performance: a8910cfcdcdb7274a81c5357a55fc4c6ef3ca5e9
   React-perflogger: faeb84f20075000ff7ddc597c5a3279a1e02f2e1
   React-RCTActionSheet: c6ba54f797b15fa1d920963171c425fca8b3868b
   React-RCTAnimation: dc00cf33f6798059f769c4546d04cdf01480baef

--- a/examples/vanilla/App.tsx
+++ b/examples/vanilla/App.tsx
@@ -21,8 +21,6 @@ import type {
   PerformanceReactNativeMark,
 } from 'react-native-performance';
 
-declare const global: { HermesInternal: null | {} };
-
 setResourceLoggingEnabled(true);
 
 const traceRender: ProfilerOnRenderCallback = (
@@ -104,11 +102,6 @@ const App = () => {
         style={styles.scrollView}
       >
         <Header />
-        {global.HermesInternal == null ? null : (
-          <View style={styles.engine}>
-            <Text style={styles.footer}>Engine: Hermes</Text>
-          </View>
-        )}
         <View style={styles.body}>
           <View style={styles.sectionContainer}>
             <Text style={styles.sectionTitle}>

--- a/examples/vanilla/android/gradle.properties
+++ b/examples/vanilla/android/gradle.properties
@@ -37,4 +37,4 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # your application. You should enable this flag either if you want
 # to write custom TurboModules/Fabric components OR use libraries that
 # are providing them.
-newArchEnabled=false
+newArchEnabled=true

--- a/examples/vanilla/ios/Podfile
+++ b/examples/vanilla/ios/Podfile
@@ -4,6 +4,8 @@ require_relative '../../../node_modules/@react-native-community/cli-platform-ios
 platform :ios, '11.0'
 install! 'cocoapods', :deterministic_uuids => false
 
+ENV['RCT_NEW_ARCH_ENABLED'] = '1'
+
 target 'Example' do
   config = use_native_modules!
 

--- a/examples/vanilla/ios/Podfile.lock
+++ b/examples/vanilla/ios/Podfile.lock
@@ -73,6 +73,7 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
+  - hermes-engine (0.11.0)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2021.06.28.00-v2):
@@ -86,6 +87,17 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
+  - RCT-Folly/Fabric (2021.06.28.00-v2):
+    - boost
+    - DoubleConversion
+    - fmt (~> 6.2.1)
+    - glog
+  - RCT-Folly/Futures (2021.06.28.00-v2):
+    - boost
+    - DoubleConversion
+    - fmt (~> 6.2.1)
+    - glog
+    - libevent
   - RCTRequired (0.68.0-rc.4)
   - RCTTypeSafety (0.68.0-rc.4):
     - FBLazyVector (= 0.68.0-rc.4)
@@ -112,8 +124,10 @@ PODS:
     - RCTRequired (= 0.68.0-rc.4)
     - RCTTypeSafety (= 0.68.0-rc.4)
     - React-Core (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
     - React-jsi (= 0.68.0-rc.4)
     - React-jsiexecutor (= 0.68.0-rc.4)
+    - React-rncore (= 0.68.0-rc.4)
     - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
   - React-Core (0.68.0-rc.4):
     - glog
@@ -261,6 +275,328 @@ PODS:
     - React-logger (= 0.68.0-rc.4)
     - React-perflogger (= 0.68.0-rc.4)
     - React-runtimeexecutor (= 0.68.0-rc.4)
+  - React-Fabric (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-Fabric/animations (= 0.68.0-rc.4)
+    - React-Fabric/attributedstring (= 0.68.0-rc.4)
+    - React-Fabric/butter (= 0.68.0-rc.4)
+    - React-Fabric/componentregistry (= 0.68.0-rc.4)
+    - React-Fabric/componentregistrynative (= 0.68.0-rc.4)
+    - React-Fabric/components (= 0.68.0-rc.4)
+    - React-Fabric/config (= 0.68.0-rc.4)
+    - React-Fabric/core (= 0.68.0-rc.4)
+    - React-Fabric/debug_core (= 0.68.0-rc.4)
+    - React-Fabric/debug_renderer (= 0.68.0-rc.4)
+    - React-Fabric/imagemanager (= 0.68.0-rc.4)
+    - React-Fabric/leakchecker (= 0.68.0-rc.4)
+    - React-Fabric/mounting (= 0.68.0-rc.4)
+    - React-Fabric/runtimescheduler (= 0.68.0-rc.4)
+    - React-Fabric/scheduler (= 0.68.0-rc.4)
+    - React-Fabric/telemetry (= 0.68.0-rc.4)
+    - React-Fabric/templateprocessor (= 0.68.0-rc.4)
+    - React-Fabric/textlayoutmanager (= 0.68.0-rc.4)
+    - React-Fabric/uimanager (= 0.68.0-rc.4)
+    - React-Fabric/utils (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/animations (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/attributedstring (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/butter (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/componentregistry (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/componentregistrynative (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/components (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-Fabric/components/activityindicator (= 0.68.0-rc.4)
+    - React-Fabric/components/image (= 0.68.0-rc.4)
+    - React-Fabric/components/inputaccessory (= 0.68.0-rc.4)
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.68.0-rc.4)
+    - React-Fabric/components/modal (= 0.68.0-rc.4)
+    - React-Fabric/components/root (= 0.68.0-rc.4)
+    - React-Fabric/components/safeareaview (= 0.68.0-rc.4)
+    - React-Fabric/components/scrollview (= 0.68.0-rc.4)
+    - React-Fabric/components/slider (= 0.68.0-rc.4)
+    - React-Fabric/components/text (= 0.68.0-rc.4)
+    - React-Fabric/components/textinput (= 0.68.0-rc.4)
+    - React-Fabric/components/unimplementedview (= 0.68.0-rc.4)
+    - React-Fabric/components/view (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/components/activityindicator (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/components/image (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/components/inputaccessory (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/components/legacyviewmanagerinterop (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/components/modal (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/components/root (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/components/safeareaview (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/components/scrollview (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/components/slider (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/components/text (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/components/textinput (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/components/unimplementedview (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/components/view (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+    - Yoga
+  - React-Fabric/config (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/core (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/debug_core (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/debug_renderer (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/imagemanager (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - React-RCTImage (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/leakchecker (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/mounting (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/runtimescheduler (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/scheduler (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/telemetry (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/templateprocessor (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/textlayoutmanager (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-Fabric/uimanager
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/uimanager (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-Fabric/utils (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - RCTRequired (= 0.68.0-rc.4)
+    - RCTTypeSafety (= 0.68.0-rc.4)
+    - React-graphics (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-graphics (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.68.0-rc.4)
+  - React-hermes (0.68.0-rc.4):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCT-Folly/Futures (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.68.0-rc.4)
+    - React-jsi (= 0.68.0-rc.4)
+    - React-jsiexecutor (= 0.68.0-rc.4)
+    - React-jsinspector (= 0.68.0-rc.4)
+    - React-perflogger (= 0.68.0-rc.4)
   - React-jsi (0.68.0-rc.4):
     - boost (= 1.76.0)
     - DoubleConversion
@@ -268,6 +604,11 @@ PODS:
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-jsi/Default (= 0.68.0-rc.4)
   - React-jsi/Default (0.68.0-rc.4):
+    - boost (= 1.76.0)
+    - DoubleConversion
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+  - React-jsi/Fabric (0.68.0-rc.4):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
@@ -285,7 +626,12 @@ PODS:
   - react-native-flipper (0.125.0):
     - React-Core
   - react-native-performance (2.1.0):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Codegen
     - React-Core
+    - ReactCommon/turbomodule/core
   - React-perflogger (0.68.0-rc.4)
   - React-RCTActionSheet (0.68.0-rc.4):
     - React-Core/RCTActionSheetHeaders (= 0.68.0-rc.4)
@@ -304,6 +650,11 @@ PODS:
     - React-jsi (= 0.68.0-rc.4)
     - React-RCTNetwork (= 0.68.0-rc.4)
     - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-RCTFabric (0.68.0-rc.4):
+    - RCT-Folly/Fabric (= 2021.06.28.00-v2)
+    - React-Core (= 0.68.0-rc.4)
+    - React-Fabric (= 0.68.0-rc.4)
+    - React-RCTImage (= 0.68.0-rc.4)
   - React-RCTImage (0.68.0-rc.4):
     - RCT-Folly (= 2021.06.28.00-v2)
     - RCTTypeSafety (= 0.68.0-rc.4)
@@ -339,6 +690,7 @@ PODS:
     - React-Core/RCTVibrationHeaders (= 0.68.0-rc.4)
     - React-jsi (= 0.68.0-rc.4)
     - ReactCommon/turbomodule/core (= 0.68.0-rc.4)
+  - React-rncore (0.68.0-rc.4)
   - React-runtimeexecutor (0.68.0-rc.4):
     - React-jsi (= 0.68.0-rc.4)
   - ReactCommon/turbomodule/core (0.68.0-rc.4):
@@ -383,8 +735,11 @@ DEPENDENCIES:
   - FlipperKit/FlipperKitUserDefaultsPlugin (= 0.125.0)
   - FlipperKit/SKIOSNetworkPlugin (= 0.125.0)
   - glog (from `../../../node_modules/react-native/third-party-podspecs/glog.podspec`)
+  - hermes-engine (~> 0.11.0)
+  - libevent (~> 2.1.12)
   - OpenSSL-Universal (= 1.1.1100)
   - RCT-Folly (from `../../../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
+  - RCT-Folly/Fabric (from `../../../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../../../node_modules/react-native/Libraries/RCTRequired`)
   - RCTTypeSafety (from `../../../node_modules/react-native/Libraries/TypeSafety`)
   - React (from `../../../node_modules/react-native/`)
@@ -395,7 +750,11 @@ DEPENDENCIES:
   - React-Core/RCTWebSocket (from `../../../node_modules/react-native/`)
   - React-CoreModules (from `../../../node_modules/react-native/React/CoreModules`)
   - React-cxxreact (from `../../../node_modules/react-native/ReactCommon/cxxreact`)
+  - React-Fabric (from `../../../node_modules/react-native/ReactCommon`)
+  - React-graphics (from `../../../node_modules/react-native/ReactCommon/react/renderer/graphics`)
+  - React-hermes (from `../../../node_modules/react-native/ReactCommon/hermes`)
   - React-jsi (from `../../../node_modules/react-native/ReactCommon/jsi`)
+  - React-jsi/Fabric (from `../../../node_modules/react-native/ReactCommon/jsi`)
   - React-jsiexecutor (from `../../../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../../../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../../../node_modules/react-native/ReactCommon/logger`)
@@ -405,12 +764,14 @@ DEPENDENCIES:
   - React-RCTActionSheet (from `../../../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../../../node_modules/react-native/Libraries/NativeAnimation`)
   - React-RCTBlob (from `../../../node_modules/react-native/Libraries/Blob`)
+  - React-RCTFabric (from `../../../node_modules/react-native/React`)
   - React-RCTImage (from `../../../node_modules/react-native/Libraries/Image`)
   - React-RCTLinking (from `../../../node_modules/react-native/Libraries/LinkingIOS`)
   - React-RCTNetwork (from `../../../node_modules/react-native/Libraries/Network`)
   - React-RCTSettings (from `../../../node_modules/react-native/Libraries/Settings`)
   - React-RCTText (from `../../../node_modules/react-native/Libraries/Text`)
   - React-RCTVibration (from `../../../node_modules/react-native/Libraries/Vibration`)
+  - React-rncore (from `../../../node_modules/react-native/ReactCommon`)
   - React-runtimeexecutor (from `../../../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../../../node_modules/react-native/ReactCommon`)
   - Yoga (from `../../../node_modules/react-native/ReactCommon/yoga`)
@@ -428,6 +789,7 @@ SPEC REPOS:
     - Flipper-RSocket
     - FlipperKit
     - fmt
+    - hermes-engine
     - libevent
     - OpenSSL-Universal
     - SocketRocket
@@ -462,6 +824,12 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/React/CoreModules"
   React-cxxreact:
     :path: "../../../node_modules/react-native/ReactCommon/cxxreact"
+  React-Fabric:
+    :path: "../../../node_modules/react-native/ReactCommon"
+  React-graphics:
+    :path: "../../../node_modules/react-native/ReactCommon/react/renderer/graphics"
+  React-hermes:
+    :path: "../../../node_modules/react-native/ReactCommon/hermes"
   React-jsi:
     :path: "../../../node_modules/react-native/ReactCommon/jsi"
   React-jsiexecutor:
@@ -482,6 +850,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/Libraries/NativeAnimation"
   React-RCTBlob:
     :path: "../../../node_modules/react-native/Libraries/Blob"
+  React-RCTFabric:
+    :path: "../../../node_modules/react-native/React"
   React-RCTImage:
     :path: "../../../node_modules/react-native/Libraries/Image"
   React-RCTLinking:
@@ -494,6 +864,8 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/Libraries/Text"
   React-RCTVibration:
     :path: "../../../node_modules/react-native/Libraries/Vibration"
+  React-rncore:
+    :path: "../../../node_modules/react-native/ReactCommon"
   React-runtimeexecutor:
     :path: "../../../node_modules/react-native/ReactCommon/runtimeexecutor"
   ReactCommon:
@@ -506,7 +878,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: 6f9aa959d414ccfd75b1f4ea70c4c16274685e20
-  FBReactNativeSpec: 292d679bd4d5497c953c032225a25c8efa05642c
+  FBReactNativeSpec: 5a32a7b86cdef8fd8c0c7a4abf8e2c05eba7c8d9
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 3d3d04a078d4f3a1b6c6916587f159dc11f232c4
@@ -518,6 +890,7 @@ SPEC CHECKSUMS:
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 476ee3e89abb49e07f822b48323c51c57124b572
+  hermes-engine: 84e3af1ea01dd7351ac5d8689cbbea1f9903ffc3
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
@@ -525,32 +898,37 @@ SPEC CHECKSUMS:
   RCTTypeSafety: c035c4f361193f3392fc184592356428895aa753
   React: 0c1dd040f86b0fbd6043cfe4ac31b16f7952d7c6
   React-callinvoker: 2b71a823b54c17dccc1786f2985728aad65247dc
-  React-Codegen: 7e0f635da2137b0737101ccfc4b71f8537669b38
+  React-Codegen: 161f29e0fd0d8d2e9973e121194304683954bb44
   React-Core: fb33cba96d122f1737062883002e8098e8d0992f
   React-CoreModules: 5e6e07df114b4f18371eb73691efb48e806c5c21
   React-cxxreact: 86316d9e41873240cdd7c91c63016bdd4adbf974
+  React-Fabric: 5aae16baea514df333a1399bb8aa06488f2687fe
+  React-graphics: 1a20cf2c4c5ebd370c1fcb707d8beeab0cc448fe
+  React-hermes: 89367c6d873979d2f2aca0751fc4d9f0dc585928
   React-jsi: 6cb5d0d06c65f5420249c4243322c815ac7d1335
   React-jsiexecutor: ffd8ee169fba7a055e2017f6be4f86a7447f14fb
   React-jsinspector: 83ab4f136376e39e8b324cef45977e1ac8100265
   React-logger: b2c25c4769127bebfaf7259b5434318665716982
   react-native-flipper: 3d9e214b412b3ce81e0d73bdcdc8097c0b0e8578
-  react-native-performance: f4b6604a9d5a8a7407e34a82fab6c641d9a3ec12
+  react-native-performance: ace4223422a2c45e627781e1d7c201d7d7d5ddd1
   React-perflogger: faeb84f20075000ff7ddc597c5a3279a1e02f2e1
   React-RCTActionSheet: c6ba54f797b15fa1d920963171c425fca8b3868b
   React-RCTAnimation: dc00cf33f6798059f769c4546d04cdf01480baef
   React-RCTBlob: 1cc0d25b083f5ef7ebb8962d58ff9dcd5f28019a
+  React-RCTFabric: e0628dba0d57cc4443710aa966771a251394ef91
   React-RCTImage: 2dabcdf4155b74d1dc42e7609e8bcae020780e7f
   React-RCTLinking: 1da77fcfcfb8c17e64afa129c57d55be86ffc95c
   React-RCTNetwork: efa95ea1cee6e0843f7a3e5c773c24ba1c6a9668
   React-RCTSettings: 37b56221569ea77e9fc247b66b83f3f2aa496de5
   React-RCTText: 067f4b687d118d0d78fa35ed7035c9678004699d
   React-RCTVibration: 42dd3d0defe49baf02cc30bd216de08233053c03
+  React-rncore: 2862dc44212ee7785656c7f2f801abbeb6df8a4b
   React-runtimeexecutor: 6f69253af03039d3ab7c226421f0536da92b0d7a
   ReactCommon: 9044455ada87b8063b3dd8d9ef113c82b1d333a4
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 13fdbd4e5a493556d2875b0be6f1ef62b6fd6c3e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 96b016b5973103e8cbf31d9536d682b30fa8cfb6
+PODFILE CHECKSUM: d097ad46b3e8fda1acd7815341b9df52c52f0c62
 
 COCOAPODS: 1.11.2

--- a/packages/react-native-performance/android/build.gradle
+++ b/packages/react-native-performance/android/build.gradle
@@ -1,3 +1,5 @@
+import java.nio.file.Paths
+
 buildscript {
     if (project == rootProject) {
         repositories {
@@ -5,24 +7,70 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:3.6.4'
+            classpath 'com.android.tools.build:gradle:4.2.2'
         }
     }
 }
 
+static def findNodeModules(baseDir) {
+    def basePath = baseDir.toPath().normalize()
+    // Node's module resolution algorithm searches up to the root directory,
+    // after which the base path will be null
+    while (basePath) {
+        def nodeModulesPath = Paths.get(basePath.toString(), "node_modules")
+        def reactNativePath = Paths.get(nodeModulesPath.toString(), "react-native")
+        if (nodeModulesPath.toFile().exists() && reactNativePath.toFile().exists()) {
+            return nodeModulesPath.toString()
+        }
+        basePath = basePath.getParent()
+    }
+    throw new GradleException("Unable to locate node_modules")
+}
+
+def isNewArchitectureEnabled() {
+    // To opt-in for the New Architecture, you can either:
+    // - Set `newArchEnabled` to true inside the `gradle.properties` file
+    // - Invoke gradle with `-newArchEnabled=true`
+    // - Set an environment variable `ORG_GRADLE_PROJECT_newArchEnabled=true`
+    return rootProject.hasProperty("newArchEnabled") && rootProject.newArchEnabled == "true"
+}
+
+if (isNewArchitectureEnabled()) {
+    apply plugin: 'com.facebook.react'
+}
 apply plugin: 'com.android.library'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
+def nodeModules = findNodeModules(projectDir)
+
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 30)
-    buildToolsVersion safeExtGet('buildToolsVersion', "30.0.2")
+    compileSdkVersion safeExtGet('compileSdkVersion', 31)
+    buildToolsVersion safeExtGet('buildToolsVersion', "31.0.0")
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 16)
-        targetSdkVersion safeExtGet('targetSdkVersion', 30)
+        minSdkVersion safeExtGet('minSdkVersion', 21)
+        targetSdkVersion safeExtGet('targetSdkVersion', 31)
+        buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
+        if (isNewArchitectureEnabled()) {
+            var appProject = rootProject.allprojects.find {it.plugins.hasPlugin('com.android.application')}
+            externalNativeBuild {
+                ndkBuild {
+                    arguments "APP_PLATFORM=android-21",
+                            "APP_STL=c++_shared",
+                            "NDK_TOOLCHAIN_VERSION=clang",
+                            "GENERATED_SRC_DIR=${appProject.buildDir}/generated/source",
+                            "PROJECT_BUILD_DIR=${appProject.buildDir}",
+                            "REACT_ANDROID_DIR=${nodeModules}/react-native/ReactAndroid",
+                            "REACT_ANDROID_BUILD_DIR=${nodeModules}/react-native/ReactAndroid/build"
+                    cFlags "-Wall", "-Werror", "-fexceptions", "-frtti", "-DWITH_INSPECTOR=1"
+                    cppFlags "-std=c++17"
+                    targets "rnperformance_modules"
+                }
+            }
+        }
     }
 
     compileOptions {
@@ -33,15 +81,38 @@ android {
 
 repositories {
     if (project == rootProject) {
-        maven {
-            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url "$rootDir/../../../node_modules/react-native/android"
+        repositories {
+            maven {
+                // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+                url("${$nodeModules}/react-native/android")
+            }
+            mavenCentral {
+                // We don't want to fetch react-native from Maven Central as there are
+                // older versions over there.
+                content {
+                    excludeGroup "com.facebook.react"
+                }
+            }
+            google()
+            maven { url 'https://www.jitpack.io' }
         }
-        google()
-        jcenter()
     }
 }
 
 dependencies {
-    implementation "com.facebook.react:react-native:+"
+    if (isNewArchitectureEnabled()) {
+        implementation project(":ReactAndroid")
+    } else {
+        implementation 'com.facebook.react:react-native:+'
+    }
+}
+
+if (isNewArchitectureEnabled()) {
+    react {
+        libraryName = "rnperformance"
+        codegenJavaPackageName = "com.oblador.performance"
+        reactNativeDir = rootProject.file("${nodeModules}/react-native")
+        jsRootDir = file("../src/")
+        codegenDir = rootProject.file("${nodeModules}/react-native-codegen")
+    }
 }

--- a/packages/react-native-performance/android/build.gradle
+++ b/packages/react-native-performance/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:4.2.2'
+            classpath 'com.android.tools.build:gradle:7.0.4'
         }
     }
 }

--- a/packages/react-native-performance/android/src/main/java/com/oblador/performance/PerformanceModule.java
+++ b/packages/react-native-performance/android/src/main/java/com/oblador/performance/PerformanceModule.java
@@ -9,12 +9,14 @@ import com.facebook.react.bridge.ReactMarker;
 import com.facebook.react.bridge.ReactMarkerConstants;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.lang.System;
 
-public class PerformanceModule extends ReactContextBaseJavaModule {
+// Should extend NativeRNPerformanceManagerSpec when codegen for old architecture is solved
+public class PerformanceModule extends ReactContextBaseJavaModule implements TurboModule {
     public static final String PERFORMANCE_MODULE = "RNPerformanceManager";
     public static final String BRIDGE_SETUP_START = "bridgeSetupStart";
 

--- a/packages/react-native-performance/ios/RNPerformanceManager.mm
+++ b/packages/react-native-performance/ios/RNPerformanceManager.mm
@@ -6,6 +6,10 @@
 #import <React/RCTRootView.h>
 #import <React/RCTPerformanceLogger.h>
 
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <RNPerformanceSpec/RNPerformanceSpec.h>
+#endif
+
 static CFTimeInterval getProcessStartTime()
 {
     size_t len = 4;
@@ -120,5 +124,12 @@ RCT_EXPORT_MODULE();
         }];
     }
 }
+
+#ifdef RCT_NEW_ARCH_ENABLED
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const facebook::react::ObjCTurboModule::InitParams &)params
+{
+    return std::make_shared<facebook::react::NativeRNPerformanceManagerSpecJSI>(params);
+}
+#endif
 
 @end

--- a/packages/react-native-performance/ios/react-native-performance.podspec
+++ b/packages/react-native-performance/ios/react-native-performance.podspec
@@ -2,6 +2,9 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, '../package.json')))
 
+folly_version = '2021.06.28.00-v2'
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
+
 Pod::Spec.new do |s|
   s.name         = package['name']
   s.version      = package['version']
@@ -15,4 +18,19 @@ Pod::Spec.new do |s|
   s.source_files = "**/*.{h,m,mm}"
 
   s.dependency 'React-Core'
+
+  # This guard prevent to install the dependencies when we run `pod install` in the old architecture.
+  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
+      s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
+      s.pod_target_xcconfig    = {
+          "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
+          "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
+      }
+
+      s.dependency "React-Codegen"
+      s.dependency "RCT-Folly", folly_version
+      s.dependency "RCTRequired"
+      s.dependency "RCTTypeSafety"
+      s.dependency "ReactCommon/turbomodule/core"
+  end
 end

--- a/packages/react-native-performance/package.json
+++ b/packages/react-native-performance/package.json
@@ -47,6 +47,15 @@
     "react-native-builder-bob": "^0.17.1",
     "typescript": "^4.1.3"
   },
+  "codegenConfig": {
+    "libraries": [
+      {
+        "name": "RNPerformanceSpec",
+        "type": "modules",
+        "jsSrcsDir": "src"
+      }
+    ]
+  },
   "react-native-builder-bob": {
     "source": "src",
     "output": "lib",

--- a/packages/react-native-performance/src/NativeRNPerformanceManager.js
+++ b/packages/react-native-performance/src/NativeRNPerformanceManager.js
@@ -1,0 +1,14 @@
+/**
+ * @flow
+ */
+
+import type { TurboModule } from 'react-native/Libraries/TurboModule/RCTExport';
+import { TurboModuleRegistry } from 'react-native';
+
+export interface Spec extends TurboModule {
+  // Events
+  +addListener: (eventName: string) => void;
+  +removeListeners: (count: number) => void;
+}
+
+export default (TurboModuleRegistry.get<Spec>('RNPerformanceManager'): ?Spec);

--- a/packages/react-native-performance/src/index.ts
+++ b/packages/react-native-performance/src/index.ts
@@ -8,9 +8,15 @@ import {
   installResourceLogger,
   uninstallResourceLogger,
 } from './resource-logger';
-
-const { RNPerformanceManager } = NativeModules;
 const { PerformanceObserver, addEntry, performance } = createPerformance();
+
+declare const global: { __turboModuleProxy: null | {} };
+
+const isTurboModuleEnabled = global.__turboModuleProxy != null;
+
+const RNPerformanceManager = isTurboModuleEnabled
+  ? require('./NativeRNPerformanceManager').default
+  : NativeModules.RNPerformanceManager;
 
 if (Platform.OS === 'android' || RNPerformanceManager) {
   const emitter = new NativeEventEmitter(RNPerformanceManager);


### PR DESCRIPTION
In preparation of the rollout of the new architecture in React Native this PR adds support for TurboModules while keeping backwards support. To ease integration for old architecture users the Android implementation is not using codegen, _but_ since the module on Android is basically only an event emitter there is quite limited value in even having it (iOS on the other hand actually has methods). 