### PR TITLE
Fix StartTimeProvider.setStartTime() on Android

### DIFF
--- a/packages/react-native-performance/android/src/main/java/com/oblador/performance/StartTimeProvider.java
+++ b/packages/react-native-performance/android/src/main/java/com/oblador/performance/StartTimeProvider.java
@@ -7,6 +7,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Process;
 import java.lang.System;
+import android.os.SystemClock;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -29,7 +30,7 @@ public class StartTimeProvider extends ContentProvider {
         if (startTime == 0) {
             long fallbackTime = endTime - Process.getElapsedCpuTime();
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                startTime = Process.getStartUptimeMillis();
+                startTime = endTime - SystemClock.uptimeMillis() - Process.getStartUptimeMillis();
                 if (endTime - startTime > MINUTE_IN_MS) {
                     startTime = fallbackTime;
                 }


### PR DESCRIPTION
The current way of determining `startTime` is to get `Process.getStartUptimeMillis()`, which is the device uptime at the time when the process was started. 
This is wrong because `startTime` should be a timestamp just like `endTime` which we set to `System.currentTimeMillis()`.

The correct way is to determine `startTime` is to do `SystemClock.uptimeMillis() - Process.getStartUptimeMillis()` to know the elapsed time since the process started, and then subtract that value to `endTime`.

The impact of this bug is limited since there is a check on the next line to use a fallback if the difference between start and end times is greater than one minute, which is always the case. But relying on `SystemClock.uptimeMillis() - Process.getStartUptimeMillis()` is more accurate than the `Process.getElapsedCpuTime()` fallback, because gives us the real elapsed time and not CPU time.