### PR TITLE
Add missing podspec to published artifact

### DIFF
--- a/packages/react-native-performance/package.json
+++ b/packages/react-native-performance/package.json
@@ -18,6 +18,7 @@
     "lib",
     "android",
     "ios",
+    "react-native-performance.*",
     "!.DS_Store",
     "!android/build",
     "!ios/build"


### PR DESCRIPTION
#81 moved podspec out of the ios folder and thus removed it from the published artifact, breaking ios autolinking which it was supposed to fix. This PR adds it to the include list and back into the artifact. 