### PR TITLE
fix: Prevent infinite recursion if global.performance is exported ponyfill

### DIFF
--- a/packages/react-native-performance/src/performance.ts
+++ b/packages/react-native-performance/src/performance.ts
@@ -11,7 +11,10 @@ import {
 } from './performance-entry';
 
 // @ts-ignore
-export const defaultNow = (): number => global.performance.now();
+const originalPerformance = global.performance;
+const originalPerformanceNow = originalPerformance.now;
+export const defaultNow = (): number =>
+  originalPerformanceNow.call(originalPerformance);
 
 export type MarkOptions = {
   startTime?: number;

--- a/packages/react-native-performance/src/performance.ts
+++ b/packages/react-native-performance/src/performance.ts
@@ -11,10 +11,10 @@ import {
 } from './performance-entry';
 
 // @ts-ignore
-const originalPerformance = global.performance;
-const originalPerformanceNow = originalPerformance.now;
-export const defaultNow = (): number =>
-  originalPerformanceNow.call(originalPerformance);
+export const defaultNow: () => number = global.performance.now.bind(
+  // @ts-ignore
+  global.performance
+);
 
 export type MarkOptions = {
   startTime?: number;

--- a/packages/react-native-performance/test/performance-now.spec.ts
+++ b/packages/react-native-performance/test/performance-now.spec.ts
@@ -1,0 +1,20 @@
+import { createPerformance } from '../src/performance';
+
+describe('as a polyfill', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('performance.now() does not cause infinite recursion', () => {
+    const { performance } = createPerformance();
+    // In react-native we can just polyfill the whole global object with `global.performance = performance`
+    // Doing the same in Node has no effect. The test would pass even without any change to `performance.ts`
+    jest
+      // @ts-ignore
+      .spyOn(global.performance, 'now')
+      .mockImplementation(performance.now.bind(performance));
+
+    // @ts-ignore
+    expect(() => global.performance.now()).not.toThrow();
+  });
+});


### PR DESCRIPTION
For APERF-943 (which we're not doing but the proposed fix seems good regardless). Verified in a minimal repro that this works. 