### PR TITLE
Fix initial event emission on iOS and tracing in example app

### DIFF
--- a/examples/vanilla/App.tsx
+++ b/examples/vanilla/App.tsx
@@ -33,7 +33,7 @@ const traceRender: ProfilerOnRenderCallback = (
   interactions // the Set of interactions belonging to this update
 ) =>
   performance.measure(id, {
-    start: performance.timeOrigin + startTime,
+    start: startTime,
     duration: actualDuration,
   });
 

--- a/examples/vanilla/ios/Example/AppDelegate.mm
+++ b/examples/vanilla/ios/Example/AppDelegate.mm
@@ -31,7 +31,6 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-  [RNPerformance.sharedInstance mark:@"appDelegateStart" ephemeral:NO];
   RCTAppSetupPrepareApp(application);
 
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
@@ -58,9 +57,8 @@
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
   dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-    [RNPerformance.sharedInstance metric:@"slowCustomMetric" value:@(420.69) detail:@{ @"unit": @"$DOGE" }];
+    [RNPerformance.sharedInstance metric:@"slowCustomMetric" value:@(420.69) detail:@{ @"unit": @"$DOGE" } ephemeral:NO];
   });
-  [RNPerformance.sharedInstance mark:@"appDelegateEnd" ephemeral:NO];
   return YES;
 }
 

--- a/packages/react-native-performance/ios/RNPerformanceManager.mm
+++ b/packages/react-native-performance/ios/RNPerformanceManager.mm
@@ -47,8 +47,12 @@ RCT_EXPORT_MODULE();
     [super setBridge:bridge];
     [RNPerformance.sharedInstance clearEphemeralEntries];
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(contentDidAppear)
+                                             selector:@selector(emitIfReady)
                                                  name:RCTContentDidAppearNotification
+                                               object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(emitIfReady)
+                                                 name:RCTJavaScriptDidLoadNotification
                                                object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(customEntryWasAdded:)
@@ -56,9 +60,9 @@ RCT_EXPORT_MODULE();
                                                object:nil];
 }
 
-- (void)contentDidAppear
+- (void)emitIfReady
 {
-    if(didEmit != YES) {
+    if (!didEmit && hasListeners && [self.bridge.performanceLogger valueForTag:RCTPLTTI] != 0 && [self.bridge.performanceLogger valueForTag:RCTPLScriptExecution] != 0) {
         [self emitEntries];
     }
 }
@@ -114,7 +118,7 @@ RCT_EXPORT_MODULE();
 - (void)startObserving
 {
     hasListeners = YES;
-    if (didEmit != YES && [self.bridge.performanceLogger valueForTag:RCTPLTTI] != 0) {
+    if (didEmit != YES && [self.bridge.performanceLogger valueForTag:RCTPLTTI] != 0 && [self.bridge.performanceLogger valueForTag:RCTPLScriptExecution] != 0) {
         [self emitEntries];
     }
 }


### PR DESCRIPTION
First and subsequent launches of the iOS app will have a different order of content appear and script events. I think this is somehow incorrect, but since these are core events I can't really fix them in this library, so instead this PR changes the logic to wait for both to have been emitted.  