### PR TITLE
feat(android): add support for AGP 8

### DIFF
--- a/packages/react-native-performance/android/build.gradle
+++ b/packages/react-native-performance/android/build.gradle
@@ -50,6 +50,11 @@ android {
     compileSdkVersion safeExtGet('compileSdkVersion', 31)
     buildToolsVersion safeExtGet('buildToolsVersion', "31.0.0")
 
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+    if (agpVersion >= 7) {
+      namespace 'com.oblador.performance'
+    }
+
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 21)
         targetSdkVersion safeExtGet('targetSdkVersion', 31)
@@ -73,9 +78,11 @@ android {
         }
     }
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+    if (agpVersion < 8) {
+      compileOptions {
+          sourceCompatibility JavaVersion.VERSION_1_8
+          targetCompatibility JavaVersion.VERSION_1_8
+      }
     }
 }
 


### PR DESCRIPTION
Change to support AGP 8 as mentioned here: https://github.com/react-native-community/discussions-and-proposals/issues/671

This does not remove package attribute from AndroidManifest to not lose compatibility with AGP < 8 (React Native < 0.71 versions). 

I don't think it's worth maintaining logic to remove that attribute contitionally since it will [only cause a warning to users on AGP 8](https://github.com/react-native-community/discussions-and-proposals/issues/671#issuecomment-1607191009) and above. 

[See Kudo's comment on why we can't set JVM version on Gradle 8](https://github.com/react-native-community/discussions-and-proposals/issues/671#issuecomment-1677632448)