### PR TITLE
fix(node): bind `performance` to support node 19+

### DIFF
--- a/packages/isomorphic-performance/src/node.js
+++ b/packages/isomorphic-performance/src/node.js
@@ -3,4 +3,4 @@ const {
   createPerformance,
 } = require('react-native-performance/lib/commonjs/performance');
 
-module.exports = createPerformance(performance.now);
+module.exports = createPerformance(performance.now.bind(performance));


### PR DESCRIPTION
This PR fixes the Node.js wrapper in `isomorphic-performance` to work in Node.js 19+, which added brand checks on `performance` in https://github.com/nodejs/node/pull/44483.

Resolves https://github.com/oblador/react-native-performance/issues/100.