### PR TITLE
fix(ios): build failure when using custom native marks

### DIFF
--- a/packages/react-native-performance/ios/RNPerformance.h
+++ b/packages/react-native-performance/ios/RNPerformance.h
@@ -1,20 +1,4 @@
 #import "RNPerformanceEntry.h"
-#include <chrono>
-
-static int64_t RNPerformanceGetTimestamp()
-{
-    // Copied from https://github.com/facebook/react-native/blob/main/React/CxxBridge/RCTJSIExecutorRuntimeInstaller.mm#L25
-    auto time = std::chrono::steady_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                        time.time_since_epoch())
-                        .count();
-
-    constexpr double NANOSECONDS_IN_MILLISECOND = 1000000.0;
-
-    return duration / NANOSECONDS_IN_MILLISECOND;
-}
-
-NSString * _Nonnull const RNPerformanceEntryWasAddedNotification = @"RNPerformanceEntryWasAdded";
 
 @interface RNPerformance: NSObject
 

--- a/packages/react-native-performance/ios/RNPerformance.mm
+++ b/packages/react-native-performance/ios/RNPerformance.mm
@@ -1,5 +1,8 @@
 #import "RNPerformance.h"
 #import "RNPerformanceEntry.h"
+#import "RNPerformanceUtils.h"
+
+NSString *const RNPerformanceEntryWasAddedNotification = @"RNPerformanceEntryWasAdded";
 
 @implementation RNPerformance
 {

--- a/packages/react-native-performance/ios/RNPerformanceManager.mm
+++ b/packages/react-native-performance/ios/RNPerformanceManager.mm
@@ -4,6 +4,7 @@
 #import <QuartzCore/QuartzCore.h>
 #import <React/RCTRootView.h>
 #import <React/RCTPerformanceLogger.h>
+#import "RNPerformanceUtils.h"
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <RNPerformanceSpec/RNPerformanceSpec.h>

--- a/packages/react-native-performance/ios/RNPerformanceUtils.h
+++ b/packages/react-native-performance/ios/RNPerformanceUtils.h
@@ -1,0 +1,23 @@
+#ifndef RNPerformanceUtils_h
+#define RNPerformanceUtils_h
+
+#import <React/RCTDefines.h>
+
+RCT_EXTERN NSString * _Nonnull const RNPerformanceEntryWasAddedNotification;
+
+#include <chrono>
+
+static int64_t RNPerformanceGetTimestamp()
+{
+    // Copied from https://github.com/facebook/react-native/blob/main/React/CxxBridge/RCTJSIExecutorRuntimeInstaller.mm#L25
+    auto time = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        time.time_since_epoch())
+                        .count();
+
+    constexpr double NANOSECONDS_IN_MILLISECOND = 1000000.0;
+
+    return duration / NANOSECONDS_IN_MILLISECOND;
+}
+
+#endif /* RNPerformanceUtils_h */


### PR DESCRIPTION
Build fails on importing `RNPeroformance.h` in Objective-C file, because `chrono` is a part of STL library which cannot be found in plain Objective-C files. The idea of fix is to prevent it to be included in a header.

`RNPerformanceEntryWasAddedNotification` declaration and initialization were split to prevent build failure as well.