### PR TITLE
fix(android): crash when library try to access JSModule before it is initialized

### DIFF
--- a/packages/react-native-performance/android/src/main/java/com/oblador/performance/PerformanceModule.java
+++ b/packages/react-native-performance/android/src/main/java/com/oblador/performance/PerformanceModule.java
@@ -187,9 +187,11 @@ public class PerformanceModule extends ReactContextBaseJavaModule implements Tur
             WritableMap map = Arguments.fromBundle(metric.getDetail());
             params.putMap("detail", map);
         }
-        getReactApplicationContext()
-                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                .emit("metric", params);
+        if (getReactApplicationContext().hasActiveCatalystInstance()) {
+            getReactApplicationContext()
+                    .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                    .emit("metric", params);
+        }
     }
 
     private void emit(PerformanceMark mark) {


### PR DESCRIPTION
This PR fixes Crash on Android when using this library #106 

To solve this problem, we need to check if ReactContext is initialized.

Ref: https://stackoverflow.com/questions/41120491/react-native-reactcontext-lifecycle-stuck-on-before-create