### PR TITLE
Fix bridgeless mode on iOS

### DIFF
--- a/examples/vanilla/ios/Example/AppDelegate.swift
+++ b/examples/vanilla/ios/Example/AppDelegate.swift
@@ -3,7 +3,6 @@ import React
 import React_RCTAppDelegate
 import ReactAppDependencyProvider
 
-
 @main
 class AppDelegate: RCTAppDelegate {
   override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
@@ -13,7 +12,7 @@ class AppDelegate: RCTAppDelegate {
     // You can add your custom initial props in the dictionary below.
     // They will be passed down to the ViewController used by React Native.
     self.initialProps = [:]
-    RNPerformance.sharedInstance().mark("myCustomMark")
+    RNPerformance.sharedInstance().mark("myCustomMark", ephemeral: false)
       /*
     [RNPerformance.sharedInstance mark:@"myCustomMark"];
     [RNPerformance.sharedInstance mark:@"myCustomMark" detail:@{ @"extra": @"info" }];

--- a/packages/react-native-performance/ios/RNPerformanceEntry.h
+++ b/packages/react-native-performance/ios/RNPerformanceEntry.h
@@ -1,3 +1,5 @@
+#import <Foundation/Foundation.h>
+
 typedef enum EntryType : NSUInteger {
     kMark,
     kMetric


### PR DESCRIPTION
The logger isn't easily accessible on bridgeless mode, but there is an alternative in the `ReactMarker::StartupLogger` singleton. The main downside with this one is that it doesn't have all the markers, nor does it update when app is reloaded. 

#111
