### PR TITLE
fix(android): soft exception when library try to access `RCTDeviceEventEmitter` before it is initialised

### DIFF
--- a/packages/react-native-performance/android/src/main/java/com/oblador/performance/PerformanceModule.java
+++ b/packages/react-native-performance/android/src/main/java/com/oblador/performance/PerformanceModule.java
@@ -187,7 +187,7 @@ public class PerformanceModule extends ReactContextBaseJavaModule implements Tur
             WritableMap map = Arguments.fromBundle(metric.getDetail());
             params.putMap("detail", map);
         }
-        if (getReactApplicationContext().hasActiveCatalystInstance()) {
+        if (getReactApplicationContext().hasActiveReactInstance()) {
             getReactApplicationContext()
                     .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                     .emit("metric", params);
@@ -202,9 +202,11 @@ public class PerformanceModule extends ReactContextBaseJavaModule implements Tur
             WritableMap map = Arguments.fromBundle(mark.getDetail());
             params.putMap("detail", map);
         }
-        getReactApplicationContext()
-                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                .emit("mark", params);
+        if (getReactApplicationContext().hasActiveReactInstance()) {
+            getReactApplicationContext()
+                    .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                    .emit("mark", params);
+        }
     }
 
     @Override
@@ -222,6 +224,6 @@ public class PerformanceModule extends ReactContextBaseJavaModule implements Tur
 
     // Fix new arch runtime error
     public void addListener(String eventName) {
-     
+
     }
 }


### PR DESCRIPTION
This PR continues the improvement introduced here: https://github.com/oblador/react-native-performance/pull/107

Currently, the app isn't crashing, but it's throwing soft exceptions when trying to emit events before `RCTDeviceEventEmitter` is initialised

```
Unhandled SoftException
com.facebook.react.bridge.ReactNoCrashSoftException: raiseSoftException(callWithExistingReactInstance(callFunctionOnModule("RCTDeviceEventEmitter", "emit"))): Execute: reactInstance is null. Dropping work.
```

To fix this, I wrapped the second emit with 

```java
if (getReactApplicationContext().hasActiveReactInstance()) {
    ...
}
```

and changed the previous `hasActiveCatalystInstance()` to `hasActiveReactInstance()` as it has been deprecated